### PR TITLE
Add support for Jacoco coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,8 @@ Listening on port 80...
 Now you can get a coverage badge from jacoco or cobertura coverage reports with,
 
 `http://host:port/jenkins/jacoco/:jenkins_url/job/:job`
+
 `http://host:port/jenkins/cobertura/:jenkins_url/job/:job`
 
-## Example
-
-![coverage](http://d7.mnpk.org/jcb/jenkins/c/http/d7.mnpk.org/jenkins/job/goyo?style=flat-square)
-```
-![coverage](http://d7.mnpk.org/jcb/jenkins/c/http/d7.mnpk.org/jenkins/job/goyo?style=flat-square)
-```
- 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -23,5 +23,9 @@ Now you can get a coverage badge from jacoco or cobertura coverage reports with,
 
 `http://host:port/jenkins/cobertura/:jenkins_url/job/:job`
 
+For https, simply add the protocol to the URL as follows:
+
+`http://host:port/jenkins/jacoco/https/:jenkins_url/job/:job`
+
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Listening on port 80...
 
 ```
 
-Now you can get coverage badge with,
+Now you can get a coverage badge from jacoco or cobertura coverage reports with,
 
-`http://host:port/jenkins/c/http/:jenkins_url/job/:job`
+`http://host:port/jenkins/jacoco/:jenkins_url/job/:job`
+`http://host:port/jenkins/cobertura/:jenkins_url/job/:job`
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Listening on port 80...
 
 ```
 
-Now you can get a coverage badge from jacoco or cobertura coverage reports with,
+Now you can get a coverage badge from **Jacoco** or **Cobertura** coverage reports with,
 
 `http://host:port/jenkins/jacoco/:jenkins_url/job/:job`
 
 `http://host:port/jenkins/cobertura/:jenkins_url/job/:job`
 
-For https, simply add the protocol to the URL as follows:
+**For https**, simply add the protocol to the URL as follows:
 
 `http://host:port/jenkins/jacoco/https/:jenkins_url/job/:job`
 

--- a/server.js
+++ b/server.js
@@ -2,49 +2,74 @@
 
 var request = require('request')
 var express = require('express')
+var xml2js = require('xml2js')
+var coberturaPath = '/jenkins/cobertura/'
+var jacocoPath = '/jenkins/jacoco/'
 
 var app = express()
+var badgeColor = function(cov) {
+	if (cov < 20) {
+		return 'red'
+	} else if (cov < 80) {
+		return 'yellow'
+	} else {
+		return 'brightgreen'
+	}
+}
+var getBadgeUrl = function(req, label, color) {
+	var badgeUrl = 'https://img.shields.io/badge/coverage-' + label + '-' + color + '.svg'
+	var style = req.param("style")
+	if (typeof style != 'undefined') {
+		badgeUrl += '?style=' + style
+	}
+	console.log('[INFO]  Generating badge: ' + badgeUrl)
+	return badgeUrl
+}
 
-app.get('/jenkins/c/http/*', function(req,res) {
-  var jurl = req.params[0]
-  var url = 'http://' + jurl + '/lastSuccessfulBuild/cobertura/api/json/?depth=2'
-  request(url, function(err, response, body) {
-    if (!err && response.statusCode == 200) {
-      var elements = JSON.parse(body)['results']['elements']
-      for (var i in elements) {
-        if (elements[i]['name'] == 'Lines') {
-          var cov = elements[i]['ratio'].toFixed(2)
-          var color = function(cov) {
-            if (cov < 20) {
-              return 'red'
-            } else if (cov < 80) {
-              return 'yellow'
-            } else {
-              return 'brightgreen'
-            }
-          }(cov)
-          var badge_url = 'https://img.shields.io/badge/coverage-' + cov.toString() + '%-' + color + '.svg'
-          var style = req.param("style")
-          if (typeof style != 'undefined') {
-            badge_url += '?style=' + style
-          }
-          console.log('[GET] ' + '/jenkins/c/http/' + jurl)
-          console.log('      generating badge(' + badge_url + ')')
-          res.redirect(badge_url)
-        }
-      }
-    } else {
-      console.log(err)
-      var badge_url = 'https://img.shields.io/badge/coverage-none-lightgrey.svg'
-      console.log('[GET] ' + '/jenkins/c/http/' + jurl)
-      console.log('      generating badge(' + badge_url + ')')
-      res.redirect(badge_url)
-    }
-  })
+//cobertura
+app.get(coberturaPath + '*', function(req,res) {
+	var jurl = req.params[0]
+	var url = 'http://' + jurl + '/lastSuccessfulBuild/cobertura/api/json/?depth=2'
+	console.log('[GET]   ' + coberturaPath + jurl)
+
+	request(url, function(err, response, body) {
+		if (!err && response.statusCode == 200) {
+			var elements = JSON.parse(body)['results']['elements']
+			for (var i in elements) {
+				if (elements[i]['name'] == 'Lines') {
+					var cov = elements[i]['ratio'].toFixed(2)
+					res.redirect(getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))
+				}
+			}
+		} else {
+			console.log('[ERROR] ' + err)
+			res.redirect(getBadgeUrl(req, 'none', 'lightgrey'))
+		}
+	})
+})
+
+//jacoco
+app.get(jacocoPath + '*', function(req,res) {
+	var jurl = req.params[0]
+	var url = 'http://' + jurl + '/lastSuccessfulBuild/jacoco/api/xml'
+	console.log('[GET]   ' + jacocoPath + jurl)
+
+	request(url, function(err, response, body) {
+		if (!err && response.statusCode == 200) {
+			var xmlParser = new xml2js.Parser();
+			xmlParser.parseString(body, function (err, result) {
+				var cov = parseFloat(result.coverageReport.lineCoverage[0].percentageFloat[0]).toFixed(2);
+				res.redirect(getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))	
+			})
+		} else {
+			console.log('[ERROR] ' + err)
+			res.redirect(getBadgeUrl(req, 'none', 'lightgrey'))
+		}
+	})
 })
 
 var port = process.argv.slice(2)[0];
 if (!port) port = 9913
-  var server = app.listen(port, function() {
-    console.log('Listening on port %d...', server.address().port)
-  })
+var server = app.listen(port, function() {
+  console.log('Listening on port %d...', server.address().port)
+})

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ var express = require('express')
 var xml2js = require('xml2js')
 var coberturaPath = '/jenkins/cobertura/'
 var jacocoPath = '/jenkins/jacoco/'
+var credentials = { user: 'jenkins-api-user', password: 'jenkins-api-token' }
 
 var app = express()
 var badgeColor = function(cov) {
@@ -18,55 +19,69 @@ var badgeColor = function(cov) {
 }
 var getBadgeUrl = function(req, label, color) {
 	var badgeUrl = 'https://img.shields.io/badge/coverage-' + label + '-' + color + '.svg'
-	var style = req.param("style")
-	if (typeof style != 'undefined') {
-		badgeUrl += '?style=' + style
+	if (req.query.style) {
+		badgeUrl += '?style=' + req.query.style
 	}
 	console.log('[INFO]  Generating badge: ' + badgeUrl)
 	return badgeUrl
 }
+var redirect = function(res, url) {
+	res.setHeader('Expires', 'Tue, 15 Apr 1980 12:00:00 GMT')
+	res.setHeader('Cache-Control', 'no-cache')
+	res.redirect(url)
+}
 
 //cobertura
-app.get(coberturaPath + '*', function(req,res) {
+var handleCobertura = function(protocol,req,res) {
 	var jurl = req.params[0]
-	var url = 'http://' + jurl + '/lastSuccessfulBuild/cobertura/api/json/?depth=2'
+	var options = { url: protocol + '://' + jurl + '/lastSuccessfulBuild/cobertura/api/json/?depth=2', auth: credentials } 
 	console.log('[GET]   ' + coberturaPath + jurl)
+	console.log('[API]   ' + options.url)
 
-	request(url, function(err, response, body) {
+	request(options, function(err, response, body) {
 		if (!err && response.statusCode == 200) {
 			var elements = JSON.parse(body)['results']['elements']
 			for (var i in elements) {
 				if (elements[i]['name'] == 'Lines') {
 					var cov = elements[i]['ratio'].toFixed(2)
-					res.redirect(getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))
+					redirect(res, getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))
 				}
 			}
 		} else {
 			console.log('[ERROR] ' + err)
-			res.redirect(getBadgeUrl(req, 'none', 'lightgrey'))
+			redirect(res, getBadgeUrl(req, 'none', 'lightgrey'))
 		}
 	})
-})
+}
+
+app.get(coberturaPath + 'https/*', function(req,res) { handleCobertura('https',req,res); })
+app.get(coberturaPath + 'http/*', function(req,res) { handleCobertura('http',req,res); })
+app.get(coberturaPath + '*', function(req,res) { handleCobertura('http',req,res); })
 
 //jacoco
-app.get(jacocoPath + '*', function(req,res) {
+var handleJacoco = function(protocol,req,res) {
 	var jurl = req.params[0]
-	var url = 'http://' + jurl + '/lastSuccessfulBuild/jacoco/api/xml'
+	var options = { url: protocol + '://' + jurl + '/lastSuccessfulBuild/jacoco/api/xml', auth: credentials }
 	console.log('[GET]   ' + jacocoPath + jurl)
+	console.log('[API]   ' + options.url)
 
-	request(url, function(err, response, body) {
+	request(options, function(err, response, body) {
 		if (!err && response.statusCode == 200) {
 			var xmlParser = new xml2js.Parser();
 			xmlParser.parseString(body, function (err, result) {
 				var cov = parseFloat(result.coverageReport.lineCoverage[0].percentageFloat[0]).toFixed(2);
-				res.redirect(getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))	
+				redirect(res, getBadgeUrl(req, cov.toString() + '%', badgeColor(cov)))	
 			})
 		} else {
 			console.log('[ERROR] ' + err)
-			res.redirect(getBadgeUrl(req, 'none', 'lightgrey'))
+			redirect(res, getBadgeUrl(req, 'none', 'lightgrey'))
 		}
 	})
-})
+}
+
+app.get(jacocoPath + 'https/*', function(req,res) { handleJacoco('https',req,res); })
+app.get(jacocoPath + 'http/*', function(req,res) { handleJacoco('http',req,res); })
+app.get(jacocoPath + '*', function(req,res) { handleJacoco('http',req,res); })
 
 var port = process.argv.slice(2)[0];
 if (!port) port = 9913


### PR DESCRIPTION
Previously there was only support for coverage badges based upon Cobertura coverage data (coming from JSON api). This adds support for coverage badges based upon Jacoco coverage data (coming from XML api). Also includes some refactoring in order to avoid code duplication.
